### PR TITLE
Mac OS Big Sur bug

### DIFF
--- a/keychain-creds.sh
+++ b/keychain-creds.sh
@@ -51,7 +51,7 @@ lock_keychain() {
 apicredentials=[]
 
 unlock_keychain
-for name in keynames ; do
+for name in $keynames ; do
     apicredentials[$name]=$( get_api_creds $name )
 done
 lock_keychain


### PR DESCRIPTION
Hi there - I recently found your article online and I'm trying to get it implemented in my environment, but came across a bug that I'd like to call out. I think that `keynames` should actually be a variable. A little more about my environment;

macOS Big Sur 11.5.2
zsh 5.8 (x86_64-apple-darwin20.0)

Original error:
```
./retrieve-osx-keychain-values:54: apicredentials: assignment to invalid subscript range
```

Hoping this will help someone else :)